### PR TITLE
lib,events: replace the attr listener of the wrapped listener with symbol.

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -53,6 +53,9 @@ const {
   codes
 } = require('internal/errors');
 const {
+  kEventListener,
+} = require('internal/util');
+const {
   ERR_INVALID_ARG_TYPE,
   ERR_OUT_OF_RANGE,
   ERR_UNHANDLED_ERROR
@@ -71,7 +74,6 @@ const kErrorMonitor = Symbol('events.errorMonitor');
 const kMaxEventTargetListeners = Symbol('events.maxEventTargetListeners');
 const kMaxEventTargetListenersWarned =
   Symbol('events.maxEventTargetListenersWarned');
-const kEventListener = Symbol('events.listener');
 
 let DOMException;
 const lazyDOMException = hideStackFrames((message, name) => {
@@ -161,12 +163,6 @@ ObjectDefineProperties(EventEmitter, {
     configurable: false,
     writable: false,
   },
-  kEventListener: {
-    value: kEventListener,
-    enumerable: false,
-    configurable: false,
-    writable: false,
-  }
 });
 
 EventEmitter.setMaxListeners =

--- a/lib/events.js
+++ b/lib/events.js
@@ -423,8 +423,11 @@ function _addListener(target, type, listener, prepend) {
     // To avoid recursion in the case that type === "newListener"! Before
     // adding it to the listeners, first emit "newListener".
     if (events.newListener !== undefined) {
-      const l = listener[kEventListener] ? listener[kEventListener] : listener;
-      target.emit('newListener', type, l);
+      target.emit(
+        'newListener',
+        type,
+        listener[kEventListener] ? listener[kEventListener] : listener
+      );
 
       // Re-assign `events` because a newListener handler could have caused the
       // this._events to be assigned to a new object
@@ -701,11 +704,9 @@ function getEventListeners(emitterOrTarget, type) {
     const root = emitterOrTarget[kEvents].get(type);
     const listeners = [];
     let handler = root?.next;
-    let handleListener = handler ? handler[kEventListener] : undefined;
-    while (handleListener !== undefined) {
-      ArrayPrototypePush(listeners, handleListener);
+    while (handler?.[kEventListener] !== undefined) {
+      ArrayPrototypePush(listeners, handler[kEventListener]);
       handler = handler.next;
-      handleListener = handler ? handler[kEventListener] : undefined;
     }
     return listeners;
   }

--- a/lib/events.js
+++ b/lib/events.js
@@ -71,6 +71,7 @@ const kErrorMonitor = Symbol('events.errorMonitor');
 const kMaxEventTargetListeners = Symbol('events.maxEventTargetListeners');
 const kMaxEventTargetListenersWarned =
   Symbol('events.maxEventTargetListenersWarned');
+const kEventListener = Symbol('events.listener');
 
 let DOMException;
 const lazyDOMException = hideStackFrames((message, name) => {
@@ -156,6 +157,12 @@ ObjectDefineProperties(EventEmitter, {
   },
   kMaxEventTargetListenersWarned: {
     value: kMaxEventTargetListenersWarned,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  },
+  kEventListener: {
+    value: kEventListener,
     enumerable: false,
     configurable: false,
     writable: false,
@@ -416,8 +423,8 @@ function _addListener(target, type, listener, prepend) {
     // To avoid recursion in the case that type === "newListener"! Before
     // adding it to the listeners, first emit "newListener".
     if (events.newListener !== undefined) {
-      target.emit('newListener', type,
-                  listener.listener ? listener.listener : listener);
+      const l = listener[kEventListener] ? listener[kEventListener] : listener;
+      target.emit('newListener', type, l);
 
       // Re-assign `events` because a newListener handler could have caused the
       // this._events to be assigned to a new object
@@ -487,7 +494,7 @@ function onceWrapper() {
 function _onceWrap(target, type, listener) {
   const state = { fired: false, wrapFn: undefined, target, type, listener };
   const wrapped = onceWrapper.bind(state);
-  wrapped.listener = listener;
+  wrapped[kEventListener] = listener;
   state.wrapFn = wrapped;
   return wrapped;
 }
@@ -520,19 +527,19 @@ EventEmitter.prototype.removeListener =
       if (list === undefined)
         return this;
 
-      if (list === listener || list.listener === listener) {
+      if (list === listener || list[kEventListener] === listener) {
         if (--this._eventsCount === 0)
           this._events = ObjectCreate(null);
         else {
           delete events[type];
           if (events.removeListener)
-            this.emit('removeListener', type, list.listener || listener);
+            this.emit('removeListener', type, list[kEventListener] || listener);
         }
       } else if (typeof list !== 'function') {
         let position = -1;
 
         for (let i = list.length - 1; i >= 0; i--) {
-          if (list[i] === listener || list[i].listener === listener) {
+          if (list[i] === listener || list[i][kEventListener] === listener) {
             position = i;
             break;
           }
@@ -618,7 +625,7 @@ function _listeners(target, type, unwrap) {
     return [];
 
   if (typeof evlistener === 'function')
-    return unwrap ? [evlistener.listener || evlistener] : [evlistener];
+    return unwrap ? [evlistener[kEventListener] || evlistener] : [evlistener];
 
   return unwrap ?
     unwrapListeners(evlistener) : arrayClone(evlistener);
@@ -676,7 +683,7 @@ function arrayClone(arr) {
 function unwrapListeners(arr) {
   const ret = arrayClone(arr);
   for (let i = 0; i < ret.length; ++i) {
-    const orig = ret[i].listener;
+    const orig = ret[i][kEventListener];
     if (typeof orig === 'function')
       ret[i] = orig;
   }
@@ -694,9 +701,11 @@ function getEventListeners(emitterOrTarget, type) {
     const root = emitterOrTarget[kEvents].get(type);
     const listeners = [];
     let handler = root?.next;
-    while (handler?.listener !== undefined) {
-      ArrayPrototypePush(listeners, handler.listener);
+    let handleListener = handler ? handler[kEventListener] : undefined;
+    while (handleListener !== undefined) {
+      ArrayPrototypePush(listeners, handleListener);
       handler = handler.next;
+      handleListener = handler ? handler[kEventListener] : undefined;
     }
     return listeners;
   }

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -39,6 +39,7 @@ const EventEmitter = require('events');
 const {
   kMaxEventTargetListeners,
   kMaxEventTargetListenersWarned,
+  kEventListener,
 } = EventEmitter;
 
 const kEvents = Symbol('kEvents');
@@ -201,7 +202,7 @@ class Listener {
     if (previous !== undefined)
       previous.next = this;
     this.previous = previous;
-    this.listener = listener;
+    this[kEventListener] = listener;
     // TODO(benjamingr) these 4 can be 'flags' to save 3 slots
     this.once = once;
     this.capture = capture;
@@ -216,7 +217,7 @@ class Listener {
   }
 
   same(listener, capture) {
-    return this.listener === listener && this.capture === capture;
+    return this[kEventListener] === listener && this.capture === capture;
   }
 
   remove() {

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -30,7 +30,7 @@ const {
 } = require('internal/errors');
 const { validateObject } = require('internal/validators');
 
-const { customInspectSymbol } = require('internal/util');
+const { customInspectSymbol, kEventListener } = require('internal/util');
 const { inspect } = require('util');
 
 const kIsEventTarget = SymbolFor('nodejs.event_target');
@@ -39,7 +39,6 @@ const EventEmitter = require('events');
 const {
   kMaxEventTargetListeners,
   kMaxEventTargetListenersWarned,
-  kEventListener,
 } = EventEmitter;
 
 const kEvents = Symbol('kEvents');

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -435,5 +435,8 @@ module.exports = {
   // Used by the buffer module to capture an internal reference to the
   // default isEncoding implementation, just in case userland overrides it.
   kIsEncodingSymbol: Symbol('kIsEncodingSymbol'),
-  kVmBreakFirstLineSymbol: Symbol('kVmBreakFirstLineSymbol')
+  kVmBreakFirstLineSymbol: Symbol('kVmBreakFirstLineSymbol'),
+
+  // Symbol use to define the wrap listener, just in case userland overrides it.
+  kEventListener: Symbol('nodejs.events.listener'),
 };

--- a/test/parallel/test-event-emitter-listeners.js
+++ b/test/parallel/test-event-emitter-listeners.js
@@ -19,12 +19,13 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// Flags: --expose-internals --no-warnings
 'use strict';
 
 require('../common');
 const assert = require('assert');
 const events = require('events');
-const { kEventListener } = events;
+const { kEventListener } = require('internal/util');
 
 function listener() {}
 

--- a/test/parallel/test-event-emitter-listeners.js
+++ b/test/parallel/test-event-emitter-listeners.js
@@ -24,6 +24,7 @@
 require('../common');
 const assert = require('assert');
 const events = require('events');
+const { kEventListener } = events;
 
 function listener() {}
 
@@ -104,11 +105,11 @@ function listener4() {
   assert.strictEqual(wrappedListeners.length, 2);
   assert.strictEqual(wrappedListeners[0], listener);
   assert.notStrictEqual(wrappedListeners[1], listener);
-  assert.strictEqual(wrappedListeners[1].listener, listener);
+  assert.strictEqual(wrappedListeners[1][kEventListener], listener);
   assert.notStrictEqual(wrappedListeners, ee.rawListeners('foo'));
   ee.emit('foo');
   assert.strictEqual(wrappedListeners.length, 2);
-  assert.strictEqual(wrappedListeners[1].listener, listener);
+  assert.strictEqual(wrappedListeners[1][kEventListener], listener);
 }
 
 {


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/36522 

Replace the attr `listener` of the wrapped listener with a symbol.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

#### Related Issues

Fixes: https://github.com/nodejs/node/issues/36522

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
